### PR TITLE
Language switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # plugin-sharing
 
-This plugin adds sharing buttons in the GitBook website toolbar to share book on social networks.
+This plugin:
+- adds sharing buttons in the GitBook website toolbar to share book on social networks
+- adds a language switch drop-down
 
-### Disable this plugin
+### Disable the sharing plugin
 
-This is a default plugin and it can be disabled using a `book.json` configuration:
+The sharing plugin is a default plugin of gitbook and comes with the gitbook installation. It can be disabled using a `book.json` configuration:
 
 ```
 {
@@ -12,11 +14,10 @@ This is a default plugin and it can be disabled using a `book.json` configuratio
 }
 ```
 
-### Configuration
+### Configure the Dynamo plug-in for social media
 
-This plugin can be configured in the `book.json`:
+To enable social network links as individual icons in the git toolbar, use this example `book.json` configuration:
 
-Default configuration is:
 
 ```js
 {
@@ -35,5 +36,81 @@ Default configuration is:
         }
     }
 }
+```
+
+### Add custom links
+
+To add a simple html link in the git toolbar, use this example `book.json` configuration:
+
+
+```js
+"dynamo": {
+      "customLinks":[
+        {
+          "label": "Download",
+          "icon": "fa fa-file-pdf-o fa-lg",
+          "url": "Appendix/DynamoPrimer-Print.pdf"
+        }]
+```
+
+- Label: does not show in the UI
+- Icon: from the font Awesome http://fontawesome.io/
+- url: used in the http a @href attribute. Can be relative or absolute
+
+
+### Add language switch drop-down
+
+Add as many language object as the current book has localized versions. Each language object will create an entry in the drop down with a link to the corresponding localized version. No need to link to self.
+
+- The language label is used in the drop down
+- The url is used to build the http a @href attribute
+
+The gitbook dropdown has an auto-layout:
+- from 1 to 3 elements, it places elements horizontally.
+- with 4 or more elements, it places them vertically
+- to obtain a vertical layout with less than 4 elements, add empty language elements, up to four. This work-around is at the expense of some padding space at the bottom of the drop-down.
+
+The currentLanguage element is optional. When present, it adds functionality:
+- the presence of currentLanguage.url links page-to-page, instead of page-to-home
+- to keep the page-to-home linking behavior, simply drop teh url property or leave it blank
+- the presence of currentLanguage.switchLangLabel adds a text label in the gitbook toolbar, next to the switch language icon. The label makes the language switch more visible. This label should be localized.
+
+Example:
+- English: "switchLangLabel":"Languages"
+- German: "switchLangLabel":"Sprachen"
+- Japanese: "switchLangLabel":"言語"
+
+
+Example configuration for German:
+
+```js
+"dynamo": {
+      "languages":[
+         {
+		"label": "English",
+		"code":"en",
+	    "url": "http://dynamoprimer.com"
+         },
+         {
+		"label": "日本語",
+		"code": "ja",
+	    "url": "http://dynamoprimer.com/ja"
+         },
+        {
+          "label": "",
+          "code":"",
+          "url": ""
+        },
+        {
+          "label": "",
+          "code":"",
+          "url": ""
+        }
+      ],
+      "currentLanguage":{
+         "code":"de",
+         "url":"http://dynamoprimer.com/de",
+         "switchLangLabel":"Sprachen"
+      }
 ```
 

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -102,16 +102,54 @@ require(["gitbook", "lodash"], function(gitbook, _) {
                 }
             });
         });
+        
+        var currentLangUrl = '';
+        if (typeof opts.currentLanguage == 'object' && typeof opts.currentLanguage.url == 'string') {
+            currentLangUrl = opts.currentLanguage.url;
+        }
 
-        // Create language switch drop down
-         var languages = opts.languages;
-         if (languages.length > 0) {
-                    gitbook.toolbar.createButton({
-                        icon: 'fa fa-language',
-                        label: 'lang',
-                        position: 'right',
-                        dropdown: [languages]
-                    });
+        var languageMenu = _.chain(opts.languages)
+            .map(function(lang) {
+                var onClickFunction;
+                if ( /^https?:\/\//.exec(currentLangUrl) ) {
+                   onClickFunction = function(e) {
+                       e.preventDefault();
+                       var pageUri = location.href.substring(currentLangUrl.length,location.href.length);
+                       // with base url of current gitbook provided, directing to same page in the target language
+                       window.open(lang.url+pageUri)
+                   };
+                } else {
+                   onClickFunction = function(e) {
+                      e.preventDefault();
+                      // when no current base url provided, directing to target home page
+                      window.open(lang.url)
+                   };
+                }
+                return {
+                    text: lang.label,
+                    onClick: onClickFunction,
+                    url: lang.url
+                };
+            })
+            .compact()
+            .value();
+
+        // findout current base url
+        var switchLangLabel = '';
+        if (typeof opts.currentLanguage == 'object' && typeof opts.currentLanguage.switchLangLabel == 'string') {
+            switchLangLabel = opts.currentLanguage.switchLangLabel;
+        }
+
+        // Create language switch button with dropdown
+         if (languageMenu.length > 0) {
+            var switchLang = '';
+            gitbook.toolbar.createButton({
+                icon: 'fa fa-globe fa-lg',
+                label: 'lang',
+                text: switchLangLabel,
+                position: 'right',
+                dropdown: [languageMenu]
+            });
          }
 
     });

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -2,7 +2,7 @@ require(["gitbook", "lodash"], function(gitbook, _) {
     var SITES = {
         'facebook': {
             'label': 'Facebook',
-            'icon': 'fa fa-facebook',
+            'icon': 'fa fa-facebook fa-lg',
             'onClick': function(e) {
                 e.preventDefault();
                 window.open("http://www.facebook.com/sharer/sharer.php?s=100&p[url]="+encodeURIComponent(location.href));
@@ -10,7 +10,7 @@ require(["gitbook", "lodash"], function(gitbook, _) {
         },
         'twitter': {
             'label': 'Twitter',
-            'icon': 'fa fa-twitter',
+            'icon': 'fa fa-twitter fa-lg',
             'onClick': function(e) {
                 e.preventDefault();
                 window.open("http://twitter.com/home?status="+encodeURIComponent(document.title+" "+location.href));
@@ -70,7 +70,7 @@ require(["gitbook", "lodash"], function(gitbook, _) {
         // Create main button with dropdown
         if (menu.length > 0) {
             gitbook.toolbar.createButton({
-                icon: 'fa fa-share-alt',
+                icon: 'fa fa-share-alt fa-lg',
                 label: 'Share',
                 position: 'right',
                 dropdown: [menu]
@@ -111,7 +111,8 @@ require(["gitbook", "lodash"], function(gitbook, _) {
         var languageMenu = _.chain(opts.languages)
             .map(function(lang) {
                 var onClickFunction;
-                if ( /^https?:\/\//.exec(currentLangUrl) ) {
+                var currentUrlRegexp = new RegExp( location.href.replace('/','\/').replace('.','\.') );
+                if ( currentUrlRegexp.exec(currentLangUrl) ) {
                    onClickFunction = function(e) {
                        e.preventDefault();
                        var pageUri = location.href.substring(currentLangUrl.length,location.href.length);
@@ -144,7 +145,7 @@ require(["gitbook", "lodash"], function(gitbook, _) {
          if (languageMenu.length > 0) {
             var switchLang = '';
             gitbook.toolbar.createButton({
-                icon: 'fa fa-globe fa-lg',
+                icon: 'fa fa-language fa-lg',
                 label: 'lang',
                 text: switchLangLabel,
                 position: 'right',

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -102,5 +102,17 @@ require(["gitbook", "lodash"], function(gitbook, _) {
                 }
             });
         });
+
+        // Create language switch drop down
+         var languages = opts.languages;
+         if (languages.length > 0) {
+                    gitbook.toolbar.createButton({
+                        icon: 'fa fa-language',
+                        label: 'lang',
+                        position: 'right',
+                        dropdown: [languages]
+                    });
+         }
+
     });
 });

--- a/assets/buttons.js
+++ b/assets/buttons.js
@@ -94,6 +94,7 @@ require(["gitbook", "lodash"], function(gitbook, _) {
             gitbook.toolbar.createButton({
                 icon: item.icon,
                 label: '',
+                text: item.text,
                 position: 'right',
                 onClick: function(e) {
                     e.preventDefault();


### PR DESCRIPTION
This PR enhances the Dynamo plugin with a language switch feature for books published in several languages. This feature is better than the native gitbook multilingual book: better integrated in UI, allows to switch language page-to-page, instead of just to the home page.
